### PR TITLE
Don't hang waiting on input from stdin with incorrect MINIFY_BUNDLES

### DIFF
--- a/jingo_minify/management/commands/compress_assets.py
+++ b/jingo_minify/management/commands/compress_assets.py
@@ -80,6 +80,10 @@ class Command(BaseCommand):  # pragma: no cover
 
                 # Concat all the files.
                 tmp_concatted = '%s.tmp' % concatted_file
+                if len(files_all) == 0:
+                    raise CommandError('No input files specified in ' +
+                        'MINIFY_BUNDLES["%s"]["%s"] in settings.py!' %
+                        (ftype, name))
                 self._call("cat %s > %s" % (' '.join(files_all), tmp_concatted),
                      shell=True)
 


### PR DESCRIPTION
If you don't specify input files for an asset in MINIFY_BUNDLES, like with the following example from kuma[1], the 'cat %s > %s' command in jingo-minify stalls waiting for user input, which is confusing to people not familiar with it.

I suggest we raise an exception instead.
## 

[1] https://github.com/mozilla/kuma/commit/8a3aec75f2f08519f1613b5c98c89935b5f80708

```
MINIFY_BUNDLES = {
    'js': {
        'mdn_home': (
            # Removing as they aren't being used at the moment

            #'js/mdn/TabInterface.js',
            #'js/mdn/home.js',
        )
    }
}
```
