### PR TITLE
Add timestamp to URLs in debug mode.

### DIFF
--- a/examples/minify/settings.py
+++ b/examples/minify/settings.py
@@ -20,9 +20,9 @@ INSTALLED_APPS = (
 
 MINIFY_BUNDLES = {
     'css': {
-        'common': [],
+        'common': ['css/test.css'],
     },
     'js': {
-        'common': [],
+        'common': ['js/test.js'],
     },
 }

--- a/jingo_minify/helpers.py
+++ b/jingo_minify/helpers.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import time
 
 from django.conf import settings
 
@@ -31,7 +32,9 @@ def js(bundle, debug=settings.TEMPLATE_DEBUG, defer=False, async=False):
     attrs = []
 
     if debug:
-        items = settings.MINIFY_BUNDLES['js'][bundle]
+        # Add timestamp to avoid caching.
+        items = ['%s?build=%s' % (item, int(time.time())) for item in
+                 settings.MINIFY_BUNDLES['js'][bundle]]
     else:
         build_id = BUILD_ID_JS
         bundle_full = "js:%s" % bundle
@@ -69,6 +72,9 @@ def css(bundle, media=False, debug=settings.TEMPLATE_DEBUG):
                 items.append('%s.css' % item)
             else:
                 items.append(item)
+
+        # Add timestamp to avoid caching.
+        items = ['%s?build=%s' % (item, int(time.time())) for item in items]
     else:
         build_id = BUILD_ID_CSS
         bundle_full = "css:%s" % bundle

--- a/jingo_minify/tests.py
+++ b/jingo_minify/tests.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 
 import jingo
+from mock import patch
 from nose.tools import eq_
 
 
@@ -14,21 +15,23 @@ def setup():
     jingo.load_helpers()
 
 
-def test_js_helper():
+@patch('jingo_minify.helpers.time.time')
+def test_js_helper(time):
     """
     Given the js() tag if we return the assets that make up that bundle
     as defined in settings.MINIFY_BUNDLES.
 
     If we're not in debug mode, we just return a minified url
     """
-
+    time.return_value = 1
     env = jingo.env
 
     t = env.from_string("{{ js('common', debug=True) }}")
     s = t.render()
 
-    expected ="\n".join(['<script src="%s"></script>' % (settings.MEDIA_URL + j)
-                        for j in settings.MINIFY_BUNDLES['js']['common']])
+    expected ="\n".join(['<script src="%s?build=1"></script>'
+                        % (settings.MEDIA_URL + j) for j in
+                        settings.MINIFY_BUNDLES['js']['common']])
 
     eq_(s, expected)
 
@@ -39,21 +42,23 @@ def test_js_helper():
            (settings.MEDIA_URL + "js/common-min.js?build=%s" % BUILD_ID_JS))
 
 
-def test_css_helper():
+@patch('jingo_minify.helpers.time.time')
+def test_css_helper(time):
     """
     Given the css() tag if we return the assets that make up that bundle
     as defined in settings.MINIFY_BUNDLES.
 
     If we're not in debug mode, we just return a minified url
     """
+    time.return_value = 1
     env = jingo.env
 
     t = env.from_string("{{ css('common', debug=True) }}")
     s = t.render()
 
     expected ="\n".join(
-        ['<link rel="stylesheet" media="screen,projection,tv" href="%s" />'
-         % (settings.MEDIA_URL + j) for j in
+        ['<link rel="stylesheet" media="screen,projection,tv" '
+        'href="%s?build=1" />' % (settings.MEDIA_URL + j) for j in
          settings.MINIFY_BUNDLES['css']['common']])
 
     eq_(s, expected)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ jingo==0.4
 Fabric==1.0.1
 nose==1.0.0
 -e git://github.com/jbalogh/django-nose.git@83c7867c3f90#egg=django-nose
+mock==0.8.0


### PR DESCRIPTION
Adds a URL parameter with a timestamp to the end of individual
JS and CSS URLs when set to debug mode. This is to avoid caching
in certain cases when developing locally, such as working on a 
test Facebook app.

Also fixes the tests to handle this change and adds media files
to the test settings that were previously empty so that the tests
actually test the right output (previously they were comparing two
empty strings due to the empty minify bundles).
