### PR TITLE
Add support for anchors in css cachebust urls.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -6,3 +6,4 @@ Andy McKay
 Austin King
 Will Kahn-Greene
 Mike Cooper
+Paul McLanahan

--- a/jingo_minify/management/commands/compress_assets.py
+++ b/jingo_minify/management/commands/compress_assets.py
@@ -261,8 +261,16 @@ class Command(BaseCommand):  # pragma: no cover
         if url.startswith('data:') or url.startswith('http'):
             return "url(%s)" % url
 
-        url = url.split('?')[0]
-        full_url = os.path.join(settings.ROOT, os.path.dirname(parent),
-                                url)
+        anchor = ''
+        if '#' in url:
+            url, anchor = url.rsplit('#', 1)
+            anchor = '#' + anchor
 
-        return "url(%s?%s)" % (url, self._file_hash(full_url))
+        url = url.split('?')[0]
+        if url.startswith('/'):
+            full_url = os.path.join(settings.ROOT, url[1:])
+        else:
+            full_url = os.path.join(settings.ROOT, os.path.dirname(parent),
+                                    url)
+
+        return "url(%s?%s%s)" % (url, self._file_hash(full_url), anchor)


### PR DESCRIPTION
- Font urls in css will often have an anchor which was causing
  "not found" errors for those files during cachebust.
- When using a domain relative url (one that starts with a /)
  the file can't be found. Change to just append the url to
  the project root for a higher likelyhood of finding the file.

Point 2 works well for bedrock anyway :)

I looked into writing tests, but no tests exist for any of the
cachebusting code, or any of compress_assets for that matter. I'll
try to get some good tests of this code going in a subsequent PR.
