### PR TITLE
Added a way to detect if a non valid setting is used and emit a warning.

### DIFF
--- a/jingo_minify/__init__.py
+++ b/jingo_minify/__init__.py
@@ -6,44 +6,42 @@ def check_css():
         from django.conf import settings
     except ImportError:
         return []
-    else:
-        w = []
 
-        less_found = False
-        sass_found = False
-        stylus_found = False
-        for bundle, csses in settings.MINIFY_BUNDLES['css'].iteritems():
-            for item in csses:
-                if item.endswith('.less'):
-                    less_found = True
-                elif item.endswith('.sass'):
-                    sass_found = True
-                elif item.endswith('.scss'):
-                    sass_found = True
-                elif item.endswith('.styl'):
-                    stylus_found = True
+    w = []
 
-        valid_less = (getattr(settings, 'LESS_BIN', False) and
-                      getattr(settings, "LESS_PREPROCESS", False))
-        valid_sass = getattr(settings, 'SASS_BIN', False)
-        valid_stylus = getattr(settings, 'STYLUS_BIN', False)
+    less_found = False
+    sass_found = False
+    stylus_found = False
+    for bundle, csses in settings.MINIFY_BUNDLES['css'].iteritems():
+        for item in csses:
+            if item.endswith('.less'):
+                less_found = True
+            elif item.endswith('.sass'):
+                sass_found = True
+            elif item.endswith('.scss'):
+                sass_found = True
+            elif item.endswith('.styl'):
+                stylus_found = True
 
-        if less_found and not valid_less:
-            w.append('LESS_BIN not found or LESS_PREPROCESS is '
-                     'False/undefined but less files are being used!')
+    valid_less = (getattr(settings, 'LESS_BIN', False) and
+                  getattr(settings, "LESS_PREPROCESS", False))
+    valid_sass = getattr(settings, 'SASS_BIN', False)
+    valid_stylus = getattr(settings, 'STYLUS_BIN', False)
 
-        if sass_found and not valid_sass:
-            w.append('SASS_BIN not found but sass files are being used!')
+    if less_found and not valid_less:
+        w.append('LESS_BIN not found or LESS_PREPROCESS is '
+                 'False/undefined but less files are being used!')
 
-        if stylus_found and not valid_stylus:
-            w.append('STYLUS_BIN not found but stylus files are being used!')
+    if sass_found and not valid_sass:
+        w.append('SASS_BIN not found but sass files are being used!')
 
-        return w
+    if stylus_found and not valid_stylus:
+        w.append('STYLUS_BIN not found but stylus files are being used!')
+
+    return w
 
 for msg in check_css():
     warnings.warn(msg)
 
 VERSION = (0, 6, 0)
 __version__ = '.'.join((str(x) for x in VERSION))
-
-

--- a/jingo_minify/tests.py
+++ b/jingo_minify/tests.py
@@ -3,8 +3,9 @@ from django.test.utils import override_settings
 
 import jingo
 from mock import ANY, call, patch
-from nose.tools import eq_
+from nose.tools import eq_, ok_
 
+from jingo_minify import check_css
 from jingo_minify.helpers import get_media_root, get_media_url
 
 try:
@@ -249,3 +250,16 @@ def test_js(getmtime, time):
          for j in settings.MINIFY_BUNDLES['js']['common']])
 
     eq_(s, expected)
+
+
+@override_settings(LESS_PREPROCESS=False,
+                   SASS_BIN=False,
+                   STYLUS_BIN=False)
+def test_check_css():
+    messages = sorted(check_css())
+    eq_(3, len(messages))
+
+    ok_(messages[0].startswith("LESS_BIN"))
+    ok_(messages[1].startswith("SASS_BIN"))
+    ok_(messages[2].startswith("STYLUS_BIN"))
+


### PR DESCRIPTION
Settings could be wrong when certain files are present. Without a
warning message it could be difficult to figure out what went wrong.

This commit adds a warning message if less/sass/style files are detected
but no valid compiler settings are detected.

Testing wise this is difficult/hacky as it would involve some sort of
output capturing. Otherwise I could return a string and print it, but
since this is an one time function that self destruct (which it does
not necessarily have to be) and a function that is not critical, it is
not included for now.

Related mozilla bug: https://bugzilla.mozilla.org/show_bug.cgi?id=874539
