### PR TITLE
Move utility functions to utils

### DIFF
--- a/jingo_minify/helpers.py
+++ b/jingo_minify/helpers.py
@@ -3,10 +3,11 @@ import subprocess
 import time
 
 from django.conf import settings
-from django.contrib.staticfiles.finders import find as static_finder
 
 import jinja2
 from jingo import register
+
+from .utils import get_media_root, get_media_url, get_path
 
 
 try:
@@ -14,54 +15,6 @@ try:
 except ImportError:
     BUILD_ID_CSS = BUILD_ID_JS = BUILD_ID_IMG = 'dev'
     BUNDLE_HASHES = {}
-
-
-def get_media_root():
-    """Return STATIC_ROOT or MEDIA_ROOT depending on JINGO_MINIFY_USE_STATIC.
-
-    This allows projects using Django 1.4 to continue using the old
-    ways, but projects using Django 1.4 to use the new ways.
-
-    """
-    if getattr(settings, 'JINGO_MINIFY_USE_STATIC', True):
-        return settings.STATIC_ROOT
-    return settings.MEDIA_ROOT
-
-
-def get_media_url():
-    """Return STATIC_URL or MEDIA_URL depending on JINGO_MINIFY_USE_STATIC.
-
-    Allows projects using Django 1.4 to continue using the old ways
-    but projects using Django 1.4 to use the new ways.
-
-    """
-    if getattr(settings, 'JINGO_MINIFY_USE_STATIC', True):
-        return settings.STATIC_URL
-    return settings.MEDIA_URL
-
-
-def get_path(path):
-    """Get a system path for a given file.
-
-    This properly handles storing files in `project/app/static`, and any other
-    location that Django's static files system supports.
-
-    ``path`` should be relative to ``STATIC_ROOT``.
-
-    """
-    debug = getattr(settings, 'DEBUG', False)
-    static = getattr(settings, 'JINGO_MINIFY_USE_STATIC', True)
-
-    full_path = os.path.join(get_media_root(), path)
-
-    if debug and static:
-        found_path = static_finder(path)
-        # If the path is not found by Django's static finder (like we are
-        # trying to get an output path), it returns None, so fall back.
-        if found_path is not None:
-            full_path = found_path
-
-    return full_path
 
 
 def _get_item_path(item):

--- a/jingo_minify/management/commands/compress_assets.py
+++ b/jingo_minify/management/commands/compress_assets.py
@@ -12,7 +12,7 @@ from django.core.management.base import BaseCommand, CommandError
 
 import git
 
-from jingo_minify.helpers import get_media_root
+from jingo_minify.utils import get_media_root
 
 
 path = lambda *a: os.path.join(get_media_root(), *a)

--- a/jingo_minify/tests.py
+++ b/jingo_minify/tests.py
@@ -5,7 +5,7 @@ import jingo
 from mock import ANY, call, patch
 from nose.tools import eq_
 
-from jingo_minify.helpers import get_media_root, get_media_url
+from .utils import get_media_root, get_media_url
 
 try:
     from build import BUILD_ID_CSS, BUILD_ID_JS

--- a/jingo_minify/utils.py
+++ b/jingo_minify/utils.py
@@ -1,0 +1,52 @@
+import os
+
+from django.conf import settings
+from django.contrib.staticfiles.finders import find as static_finder
+
+
+def get_media_root():
+    """Return STATIC_ROOT or MEDIA_ROOT depending on JINGO_MINIFY_USE_STATIC.
+
+    This allows projects using Django 1.4 to continue using the old
+    ways, but projects using Django 1.4 to use the new ways.
+
+    """
+    if getattr(settings, 'JINGO_MINIFY_USE_STATIC', True):
+        return settings.STATIC_ROOT
+    return settings.MEDIA_ROOT
+
+
+def get_media_url():
+    """Return STATIC_URL or MEDIA_URL depending on JINGO_MINIFY_USE_STATIC.
+
+    Allows projects using Django 1.4 to continue using the old ways
+    but projects using Django 1.4 to use the new ways.
+
+    """
+    if getattr(settings, 'JINGO_MINIFY_USE_STATIC', True):
+        return settings.STATIC_URL
+    return settings.MEDIA_URL
+
+
+def get_path(path):
+    """Get a system path for a given file.
+
+    This properly handles storing files in `project/app/static`, and any other
+    location that Django's static files system supports.
+
+    ``path`` should be relative to ``STATIC_ROOT``.
+
+    """
+    debug = getattr(settings, 'DEBUG', False)
+    static = getattr(settings, 'JINGO_MINIFY_USE_STATIC', True)
+
+    full_path = os.path.join(get_media_root(), path)
+
+    if debug and static:
+        found_path = static_finder(path)
+        # If the path is not found by Django's static finder (like we are
+        # trying to get an output path), it returns None, so fall back.
+        if found_path is not None:
+            full_path = found_path
+
+    return full_path


### PR DESCRIPTION
Moving these three utility functions to their own module makes it easier
to import them without creating a Jinja2 environment as triggered by
registering helpers

Quick r?
