### PR TITLE
Call minify if minified file doesn't exist

### DIFF
--- a/jingo_minify/management/commands/compress_assets.py
+++ b/jingo_minify/management/commands/compress_assets.py
@@ -103,7 +103,7 @@ class Command(BaseCommand):  # pragma: no cover
                 # Compresses the concatenations.
                 is_changed = self._is_changed(concatted_file)
                 self._clean_tmp(concatted_file)
-                if is_changed:
+                if is_changed or not os.path.isfile(compressed_file):
                     self._minify(ftype, concatted_file, compressed_file)
                 elif self.v:
                     print "File unchanged, skipping minification of %s" % (


### PR DESCRIPTION
It can occur that the minified file has been deleted or not generated (this was my case) but the concatted version has been generated. So when rerunning the command, testing only if the concatted version is up to date ends with the minified file never generated again.
This PR fix this by testing also if the minified file exists. If not, the minify command will be called.

Thanks :)

Yohan
