### PR TITLE
Fix for missing bin/yuicompressor.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,4 @@ include LICENSE
 include CONTRIBUTORS
 include README.rst
 include CHANGES.rst
-include jingo_minify/bin/yuicompressor-2.4.7.jar
+recursive-include jingo_minify/bin *


### PR DESCRIPTION
The deleted line did not include /bin/yuicompressor-2.4.7 during a pip install. Changing it to recursive-include fixed it.
