### PR TITLE
An an option to generate a unique build id without using git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ pip-log.txt
 build
 dist
 *.egg-info
+examples/minify/build.py
+examples/minify/static/css/common_multi-all.css

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: python
 python:
  - "2.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: python
 python:
- - "2.6"
  - "2.7"
 install: pip install -r requirements.txt
 script: python run_tests.py

--- a/examples/minify/settings.py
+++ b/examples/minify/settings.py
@@ -53,3 +53,5 @@ LESS_BIN = '/usr/bin/lessc'
 
 SASS_PREPROCESS = True
 SASS_BIN = '/usr/bin/sass'
+
+JAVA_BIN = 'java'

--- a/examples/minify/settings.py
+++ b/examples/minify/settings.py
@@ -9,6 +9,7 @@ MEDIA_ROOT = '/media'
 MEDIA_URL = ''
 STATIC_ROOT = path('static')
 STATIC_URL = ''
+SECRET_KEY = 'my super secret key'
 
 DATABASES = {
     'default': {

--- a/jingo_minify/tests.py
+++ b/jingo_minify/tests.py
@@ -31,7 +31,7 @@ def test_js_helper(getmtime, time):
     """
     getmtime.return_value = 1
     time.return_value = 1
-    env = jingo.env
+    env = jingo.get_env()
 
     t = env.from_string("{{ js('common', debug=True) }}")
     s = t.render()
@@ -98,7 +98,7 @@ def test_css_helper(getmtime, time):
     """
     getmtime.return_value = 1
     time.return_value = 1
-    env = jingo.env
+    env = jingo.get_env()
 
     t = env.from_string("{{ css('common', debug=True) }}")
     s = t.render()
@@ -167,7 +167,7 @@ def test_css_helper(getmtime, time):
 
 
 def test_inline_css_helper():
-    env = jingo.env
+    env = jingo.get_env()
     t = env.from_string("{{ inline_css('common', debug=True) }}")
     s = t.render()
 
@@ -182,7 +182,7 @@ def test_inline_css_helper():
 
 
 def test_inline_css_helper_multiple_files():
-    env = jingo.env
+    env = jingo.get_env()
     t = env.from_string("{{ inline_css('common_multi', debug=True) }}")
     s = t.render()
 
@@ -198,7 +198,7 @@ def test_inline_css_helper_multiple_files():
 
 
 def test_inline_css_helper_external_url():
-    env = jingo.env
+    env = jingo.get_env()
 
     t = env.from_string("{{ inline_css('common_url', debug=True) }}")
     s = t.render()
@@ -215,23 +215,23 @@ def test_inline_css_helper_external_url():
 
 @override_settings(STATIC_ROOT='static',
                    MEDIA_ROOT='media',
-                   STATIC_URL='http://example.com/static',
-                   MEDIA_URL='http://example.com/media')
+                   STATIC_URL='http://example.com/static/',
+                   MEDIA_URL='http://example.com/media/')
 def test_no_override():
     """No override uses STATIC versions."""
     eq_(get_media_root(), 'static')
-    eq_(get_media_url(), 'http://example.com/static')
+    eq_(get_media_url(), 'http://example.com/static/')
 
 
 @override_settings(JINGO_MINIFY_USE_STATIC=False,
                    STATIC_ROOT='static',
                    MEDIA_ROOT='media',
-                   STATIC_URL='http://example.com/static',
-                   MEDIA_URL='http://example.com/media')
+                   STATIC_URL='http://example.com/static/',
+                   MEDIA_URL='http://example.com/media/')
 def test_static_override():
     """Overriding to False uses MEDIA versions."""
     eq_(get_media_root(), 'media')
-    eq_(get_media_url(), 'http://example.com/media')
+    eq_(get_media_url(), 'http://example.com/media/')
 
 
 @override_settings(STATIC_ROOT='static',
@@ -243,7 +243,7 @@ def test_static_override():
 def test_css(getmtime, time):
     getmtime.return_value = 1
     time.return_value = 1
-    env = jingo.env
+    env = jingo.get_env()
 
     t = env.from_string("{{ css('common', debug=True) }}")
     s = t.render()
@@ -267,7 +267,7 @@ def test_css(getmtime, time):
 @patch('jingo_minify.helpers.subprocess')
 @patch('__builtin__.open', spec=True)
 def test_compiled_css(open_mock, subprocess_mock, getmtime_mock, time_mock):
-    jingo.env.from_string("{{ css('compiled', debug=True) }}").render()
+    jingo.get_env().from_string("{{ css('compiled', debug=True) }}").render()
 
     eq_(subprocess_mock.Popen.mock_calls,
         [call(['lessc-bin', 'static/css/less.less'], stdout=ANY),
@@ -289,7 +289,7 @@ def test_compiled_css(open_mock, subprocess_mock, getmtime_mock, time_mock):
 def test_js(getmtime, time):
     getmtime.return_value = 1
     time.return_value = 1
-    env = jingo.env
+    env = jingo.get_env()
 
     t = env.from_string("{{ js('common', debug=True) }}")
     s = t.render()

--- a/jingo_minify/tests.py
+++ b/jingo_minify/tests.py
@@ -306,7 +306,10 @@ def test_js(getmtime, time):
 @patch('jingo_minify.helpers.subprocess')
 def test_compress_assets_command_with_git(subprocess_mock):
     build_id_file = os.path.realpath(os.path.join(settings.ROOT, 'build.py'))
-    os.remove(build_id_file)
+    try:
+        os.remove(build_id_file)
+    except OSError:
+        pass
     call_command('compress_assets')
     ok_(os.path.exists(build_id_file))
     with open(build_id_file) as f:
@@ -326,7 +329,10 @@ def test_compress_assets_command_with_git(subprocess_mock):
 @patch('jingo_minify.helpers.subprocess')
 def test_compress_assets_command_without_git(subprocess_mock):
     build_id_file = os.path.realpath(os.path.join(settings.ROOT, 'build.py'))
-    os.remove(build_id_file)
+    try:
+        os.remove(build_id_file)
+    except OSError:
+        pass
     call_command('compress_assets')
     ok_(os.path.exists(build_id_file))
     with open(build_id_file) as f:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.4.5
-jingo==0.4
--e git://github.com/jbalogh/django-nose.git@83c7867c3f90ff3c7c7471716da91b643e8b2c01#egg=django_nose-dev
-mock==1.0b1
+Django==1.8.17
+jingo==0.9.0
+django-nose==1.4.4
+mock==2.0.0

--- a/run_tests.py
+++ b/run_tests.py
@@ -12,6 +12,8 @@ sys.path.insert(0, os.path.join(ROOT, 'examples'))
 
 # This can't be imported until after we've fiddled with the
 # environment.
+import django
+django.setup()
 from django.test.utils import setup_test_environment
 setup_test_environment()
 


### PR DESCRIPTION
So, this package is deprecated, but mozilla/addons-server is still using it. We are planning to get rid of it, but in the meantime, we want to remove the dependency it has on `git` now to [help our build process](https://github.com/mozilla/addons-server/issues/3503). 

And that's why I'm making this PR :) It adds a `--use-uuid` option to the `compress_assets` command, keeping backwards-compatibility intact. The tests are rather dumb, but at least they exist now...